### PR TITLE
Implement news-backed market analysis pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,12 +88,14 @@ This project uses SST v3 (ESM JavaScript) with OpenAI + Weaviate. Follow the con
 - `requestValidator` parses JSON when request bodies are strings and logs invalid payloads before throwing.
 
 ## Integration Flow (Current)
-- Master data generation -> enqueue assessment -> enqueue competition.
+- Master data generation -> enqueue assessment -> enqueue competition (customers only).
+- Competitor assessment/news/analysis reuse the same pipeline (subjectType=`competitor`) without re-running competition.
 - Handlers check Weaviate for existing entries before generating new ones.
-- News download -> vector store file batch -> Step Functions polling -> enqueue MarketAnalysis.
+- News download -> vector store file batch -> Step Functions polling -> enqueue MarketAnalysis with `vectorStoreId`.
+- Queue payloads that include a domain must also include `customerDomain` and `subjectType` (`customer` | `competitor`) and preserve them downstream.
 
 ## Gotchas
 - `z.coerce.date()` is fine for internal validation, but OpenAI structured outputs return JSON strings; use string dates in model-facing schemas if needed and coerce after parsing.
 - Ensure `mapZodToWeaviateProperties` is used for collections to avoid invalid schema payloads.
 - Vector store polling interval/attempts are deployment-time constants in `sst.config.ts`.
-- Market analysis requests accept optional `vectorStoreId` to drive vector store usage downstream.
+- Market analysis requests must carry `vectorStoreId` to drive news-signal retrieval downstream.

--- a/src/cmd/generateMasterData.js
+++ b/src/cmd/generateMasterData.js
@@ -1,6 +1,6 @@
 
 import { z } from "zod";
-import {legalName, domain} from "../model.js"
+import {legalName, domain, subjectType} from "../model.js"
 import ValidationCreator from "../util/request.js"
 import { generatePrompt } from "../util/openai.js";
 import Model from "../model.js"
@@ -12,9 +12,15 @@ const oc = new OpenAI({
 });
 
 const requestSchema = z.object({
+  customerDomain: domain.optional(),
   legalName,
-  domain
-}).describe("Request to generate master data for a company");
+  domain,
+  subjectType: subjectType.optional(),
+}).transform((value) => ({
+  ...value,
+  customerDomain: value.customerDomain ?? value.domain,
+  subjectType: value.subjectType ?? "customer",
+})).describe("Request to generate master data for a company");
 
 export const requestValidator = ValidationCreator(requestSchema)
 
@@ -57,4 +63,3 @@ export default async function(request) {
     });
     return response.output_parsed
 }
-

--- a/src/handler/competition/subscribe.downstream.js
+++ b/src/handler/competition/subscribe.downstream.js
@@ -1,7 +1,11 @@
 import { getClient } from "../../weaviate.js";
 import GenerateCompetition, { requestValidator } from "../../cmd/generateCompetition.js";
+import GenerateMasterData from "../../cmd/generateMasterData.js";
 import Model from "../../model.js";
+import { Resource } from "sst";
+import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
 const model = Model.competingCompanies;
+const sqs = new SQSClient({});
 
 export async function handler(event) {
 
@@ -9,15 +13,68 @@ export async function handler(event) {
     const req = requestValidator(record.body);
     const wv = await getClient();
 
-    let competition = await model.fetchObject(wv, req.domain);
+    let competition = await model.fetchObject(wv, req.customerDomain);
     const foundEntry = competition != null;
 
     if (!foundEntry) {
-      console.log("Could not find competition list, will generate.", req.domain);
+      console.log("Could not find competition list, will generate.", req.customerDomain);
       competition = await GenerateCompetition(req);
       await model.insertObject(wv, competition);
     } else {
-      console.log("Found competition list, will skip", req.domain);
+      console.log("Found competition list, will skip", req.customerDomain);
+    }
+
+    const competitionEntries = competition?.competition ?? [];
+    const processedDomains = new Set();
+    const customerMaster = await Model.companyMasterData.fetchObject(
+      wv,
+      req.customerDomain
+    );
+
+    if (!customerMaster) {
+      console.warn(
+        "Missing customer master data before linking competitors",
+        req.customerDomain
+      );
+    }
+
+    for (const item of competitionEntries) {
+      if (!item?.competitionDomain || processedDomains.has(item.competitionDomain)) {
+        continue;
+      }
+      processedDomains.add(item.competitionDomain);
+
+      const competitorReq = {
+        customerDomain: req.customerDomain,
+        domain: item.competitionDomain,
+        legalName: item.competitionLegalName,
+        subjectType: "competitor",
+      };
+
+      let competitorMaster = await Model.companyMasterData.fetchObject(
+        wv,
+        competitorReq.domain
+      );
+      if (!competitorMaster) {
+        competitorMaster = await GenerateMasterData(competitorReq);
+        await Model.companyMasterData.insertObject(wv, competitorMaster);
+      }
+
+      if (customerMaster && competitorMaster) {
+        await Model.companyMasterData.linkObjects(
+          wv,
+          "competingCompanies",
+          customerMaster,
+          competitorMaster
+        );
+      }
+
+      await sqs.send(
+        new SendMessageCommand({
+          QueueUrl: Resource.AssessmentQueue.url,
+          MessageBody: JSON.stringify(competitorReq),
+        })
+      );
     }
   }
 

--- a/src/handler/loadintovectorstore/check.batch.js
+++ b/src/handler/loadintovectorstore/check.batch.js
@@ -9,15 +9,17 @@ const oc = new OpenAI({
 
 const requestSchema = z
   .object({
-    vectorStoreId: z.string().min(1).optional(),
+    vectorStoreId: z.string().min(1),
     vectorStoreName: z.string().min(1),
     batchId: z.string().min(1),
     context: z
       .object({
         domain: z.string().min(1),
+        customerDomain: z.string().min(1),
         legalName: z.string().min(1),
         industries: z.array(z.string().min(1)),
         markets: z.array(z.string().min(1)),
+        subjectType: z.string().min(1),
       })
       .passthrough(),
   })

--- a/src/handler/marketanalysis/subscribe.downstream.js
+++ b/src/handler/marketanalysis/subscribe.downstream.js
@@ -15,13 +15,17 @@ export async function handler(event) {
     const foundEntry = analysis != null;
 
     if (!foundEntry) {
-      console.log("Could not find market analysis, will generate.", req.domain);
+      console.log("Could not find market analysis, will generate.", req.domain, req.subjectType);
       analysis = await GenerateMarketAnalysis(req);
       await model.insertObject(wv, analysis)
       const master = await Model.companyMasterData.fetchObject(wv, req.domain)
-      await Model.companyMasterData.linkObjects(wv, "marketAnalysis", master, analysis)
+      if (master) {
+        await Model.companyMasterData.linkObjects(wv, "marketAnalysis", master, analysis)
+      } else {
+        console.warn("Missing master data while linking market analysis", req.domain)
+      }
     } else {
-      console.log("Found market analysis, will skip", req.domain);
+      console.log("Found market analysis, will skip", req.domain, req.subjectType);
     }
   }
 

--- a/src/handler/news/subscribe.fanout.js
+++ b/src/handler/news/subscribe.fanout.js
@@ -23,7 +23,9 @@ export async function handler(event) {
         console.log("Will skip: ", item.source)
       }
       const downloadReq = {
+        customerDomain: req.customerDomain,
         domain: item.domain,
+        subjectType: req.subjectType,
         url: item.source,
         fallback: item.summary,
         vectorStore: `news/${item.domain}`,

--- a/src/model.js
+++ b/src/model.js
@@ -6,6 +6,7 @@ import { fetchObject, insertObject, linkObject} from "./weaviate";
 
 export const legalName = z.string().min(1).max(255).describe("The complete legal name of the company")
 export const domain = z.string().min(1).max(255).describe("The main domain of the company homepage in the format of name.tld")
+export const subjectType = z.enum(["customer", "competitor"]).describe("Whether the subject is the original customer or a competitor")
 export const markets = z.array(
   z.string().min(2).max(2).describe("ISO 3166-1 alpha-2 country code, or glaobal in case of a glabal acting entity"),
 ).describe("Primary markets generating >= 80% of revenue");
@@ -57,6 +58,8 @@ const competingCompaniesSchema = z.object({
 
 const companyAssessment = z.object({
   domain,
+  customerDomain: domain.describe("The originating customer domain for this assessment"),
+  subjectType,
   revenueInMio: createEstimate(revenueInMio).describe("Annual Revenue"),
   revenueGrowth: createEstimate(z.number().describe("Annual Growth in Revenue since last year in Percent")).describe("Annual Growth"),
   numberOfEmployees: createEstimate(z.number().describe("Staff Headcount")).describe("Staff"),
@@ -72,11 +75,16 @@ const companyAssessment = z.object({
 
 const marketAnalysis = z.object({
   domain,
+  customerDomain: domain.describe("The originating customer domain for this market analysis"),
+  subjectType,
+  vectorStoreId: z.string().min(1).describe("The vector store containing related news signals"),
   analysis: z.string().describe("A complete anlaysis of the market for the customer")
 }).describe("Market Analysis")
 
 const companyNews = z.object({
   domain,
+  customerDomain: domain.describe("The originating customer domain for this news item"),
+  subjectType,
   source: z.string().min(1).max(2048).describe("Public URL of the source"),
   summary: z.string().min(1).describe("Concise summary of the news item"),
   date: z.string().min(1).describe("Publication date in ISO 8601 format (YYYY-MM-DD)"),
@@ -151,6 +159,7 @@ const registry = {
       "assessment": COMPANY_ASSESSMENT_COLLECTION,
       "marketAnalysis": MARKET_ANALYSIS_COLLECTION,
       "news": COMPANY_NEWS_COLLECTION,
+      "competingCompanies": COMPANY_MASTER_DATA_COLLECTION,
     },
     []
   ),

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -69,7 +69,7 @@ export default $config({
       name: "NotifyMarketAnalysis",
       queue: MarketAnalysisQueue,
       messageBody:
-        "{% $string({\"legalName\": $states.input.context.legalName, \"domain\": $states.input.context.domain, \"industries\": $states.input.context.industries, \"markets\": $states.input.context.markets, \"vectorStoreId\": $states.input.vectorStoreId}) %}",
+        "{% $string({\"legalName\": $states.input.context.legalName, \"domain\": $states.input.context.domain, \"customerDomain\": $states.input.context.customerDomain, \"subjectType\": $states.input.context.subjectType, \"industries\": $states.input.context.industries, \"markets\": $states.input.context.markets, \"vectorStoreId\": $states.input.vectorStoreId}) %}",
     });
 
     const checkBatchStatus = sst.aws.StepFunctions.lambdaInvoke({


### PR DESCRIPTION
## Summary
- propagate `customerDomain` and `subjectType` through queue payloads, schemas, and models, adding competitor links from customers to master data records
- fan out competitors into the standard assessment/news/analysis pipeline and preserve context for vector store ingestion and market analysis
- pull news signals via OpenAI file search for market analysis requests and document the updated flow

## Testing
- pnpm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69565210185c832b93044552da3135e4)