### PR TITLE
Add competition analysis pipeline and schema

### DIFF
--- a/src/cmd/generateCompetitionAnalysis.js
+++ b/src/cmd/generateCompetitionAnalysis.js
@@ -1,0 +1,90 @@
+import { z } from "zod";
+import OpenAI from "openai";
+import { Resource } from "sst";
+import ValidationCreator from "../util/request.js";
+import { domain, legalName } from "../model.js";
+import { generatePrompt } from "../util/openai.js";
+import Model from "../model.js";
+
+const oc = new OpenAI({
+  apiKey: Resource.OpenAIApiKey.value,
+});
+
+const requestSchema = z.object({
+  customerDomain: domain,
+  competitorDomain: domain,
+  customerLegalName: legalName,
+  competitorLegalName: legalName,
+  customerMarketAnalysis: z.string().min(1),
+  competitorMarketAnalysis: z.string().min(1),
+  customerVectorStoreId: z.string().min(1),
+  competitorVectorStoreId: z.string().min(1),
+});
+
+export const requestValidator = ValidationCreator(requestSchema);
+
+const promptTemplate = {
+  instructions: `
+You are a competitive analyst. Compare the competitor with the customer.
+
+Use file_search for news signals from both vector stores before writing.
+Use web_search to validate facts and gather missing citations.
+Use Weaviate evidence (market analysis embeddings + retrieved context) to ground the comparison.
+Separate facts from inferred insights.`,
+  input: `
+Customer:
+- Name: <%= req.customerLegalName %>
+- Domain: <%= req.customerDomain %>
+- Market analysis: <%= req.customerMarketAnalysis %>
+
+Competitor:
+- Name: <%= req.competitorLegalName %>
+- Domain: <%= req.competitorDomain %>
+- Market analysis: <%= req.competitorMarketAnalysis %>
+
+Required sections (structured output):
+1) Summary (short, 5-8 bullets)
+2) Strengths (competitor vs customer; list)
+3) Weaknesses (competitor vs customer; list)
+4) Niche positioning comparison (short narrative)
+5) Market trends impact (list + short narrative)
+6) Customer expectations alignment (list + short narrative)
+7) Sources (title, publisher, url, date)
+
+Output rules:
+- Return JSON only matching the schema.
+- Escape newlines/tabs in strings.
+- Keep analysis under 3500 chars, summary under 1200 chars.
+- Set "id" to "<%= req.customerDomain %>|<%= req.competitorDomain %>" in the response.
+- Include competitorDomain in the output.`,
+};
+
+const model = Model.competitionAnalysis;
+
+export default async function generateCompetitionAnalysis(request) {
+  const req = requestValidator(request);
+  const prompt = generatePrompt(promptTemplate, { req });
+
+  const response = await oc.responses.parse({
+    model: "gpt-4o-mini",
+    tools: [
+      {
+        type: "file_search",
+        vector_store_ids: [req.customerVectorStoreId, req.competitorVectorStoreId],
+      },
+      { type: "web_search" },
+    ],
+    ...prompt,
+    ...model.openAIFormat,
+  });
+
+  const parsed = response.output_parsed;
+  return {
+    ...parsed,
+    id: `${req.customerDomain}|${req.competitorDomain}`,
+    customerDomain: req.customerDomain,
+    competitorDomain: req.competitorDomain,
+    customerLegalName: req.customerLegalName,
+    competitorLegalName: req.competitorLegalName,
+  };
+}

--- a/src/cmd/generateCompetitionAnalysisEmbedding.js
+++ b/src/cmd/generateCompetitionAnalysisEmbedding.js
@@ -1,0 +1,88 @@
+import { z } from "zod";
+import OpenAI from "openai";
+import { Resource } from "sst";
+import ValidationCreator from "../util/request.js";
+
+const oc = new OpenAI({
+  apiKey: Resource.OpenAIApiKey.value,
+});
+
+const requestSchema = z.object({
+  analysis: z.string().min(1),
+  newsSnippets: z.array(z.string().min(1)).optional(),
+});
+
+const requestValidator = ValidationCreator(requestSchema);
+
+function splitIntoChunks(text, maxLength = 1200) {
+  const paragraphs = text
+    .split(/\n\s*\n/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  const chunks = [];
+  let current = "";
+
+  for (const paragraph of paragraphs) {
+    if (!paragraph) continue;
+    if ((current + "\n\n" + paragraph).trim().length <= maxLength) {
+      current = current ? `${current}\n\n${paragraph}` : paragraph;
+      continue;
+    }
+    if (current) {
+      chunks.push(current);
+    }
+    if (paragraph.length > maxLength) {
+      chunks.push(paragraph.slice(0, maxLength));
+      current = paragraph.slice(maxLength);
+    } else {
+      current = paragraph;
+    }
+  }
+
+  if (current) {
+    chunks.push(current);
+  }
+
+  return chunks;
+}
+
+function averageVectors(vectors) {
+  if (!vectors.length) return [];
+  const length = vectors[0].length;
+  const sums = new Array(length).fill(0);
+  for (const vec of vectors) {
+    for (let i = 0; i < length; i += 1) {
+      sums[i] += vec[i];
+    }
+  }
+  return sums.map((value) => value / vectors.length);
+}
+
+export default async function generateCompetitionAnalysisEmbedding(request) {
+  const req = requestValidator(request);
+  const evidenceChunks = splitIntoChunks(req.analysis);
+
+  const embeddings = [];
+  for (const chunk of evidenceChunks) {
+    const evidence = [
+      ...(req.newsSnippets ?? []),
+      chunk,
+    ]
+      .join(" ")
+      .trim();
+
+    const text = `Evidence: ${evidence}. Task: compare strengths, weaknesses, niches, trends, and expectations for customer vs competitor.`;
+
+    const response = await oc.embeddings.create({
+      model: "text-embedding-3-small",
+      input: text,
+    });
+
+    embeddings.push(response.data[0].embedding);
+  }
+
+  return averageVectors(embeddings);
+}
+
+export { requestValidator };

--- a/src/handler/competitionanalysis/subscribe.downstream.js
+++ b/src/handler/competitionanalysis/subscribe.downstream.js
@@ -1,0 +1,192 @@
+import { Filters } from "weaviate-client";
+import OpenAI from "openai";
+import { Resource } from "sst";
+import { z } from "zod";
+import { getClient } from "../../weaviate.js";
+import GenerateCompetitionAnalysis from "../../cmd/generateCompetitionAnalysis.js";
+import Model, { domain, legalName } from "../../model.js";
+import ValidationCreator from "../../util/request.js";
+
+const requestSchema = z.object({
+  customerDomain: domain,
+  competitorDomain: domain,
+  customerLegalName: legalName,
+  competitorLegalName: legalName,
+  customerVectorStoreId: z.string().min(1),
+  competitorVectorStoreId: z.string().min(1),
+  customerMarketAnalysisId: z.string().min(1),
+  competitorMarketAnalysisId: z.string().min(1),
+});
+
+const requestValidator = ValidationCreator(requestSchema);
+
+const oc = new OpenAI({
+  apiKey: Resource.OpenAIApiKey.value,
+});
+
+const QUESTION_PROMPT =
+  "Compare competitive strengths and weaknesses, niche positioning, market trends, and customer expectations for customer vs competitor.";
+
+export async function handler(event) {
+  for (const record of event.Records ?? []) {
+    const req = requestValidator(record.body);
+    const wv = await getClient();
+
+    const competitionId = `${req.customerDomain}|${req.competitorDomain}`;
+    const existing = await Model.competitionAnalysis.fetchObject(wv, competitionId);
+    if (existing) {
+      console.log("Competition analysis already exists, skipping", competitionId);
+      continue;
+    }
+
+    const customerMarketAnalysis = await Model.marketAnalysis.fetchObject(
+      wv,
+      req.customerMarketAnalysisId
+    );
+    const competitorMarketAnalysis = await Model.marketAnalysis.fetchObject(
+      wv,
+      req.competitorMarketAnalysisId
+    );
+
+    if (!customerMarketAnalysis || !competitorMarketAnalysis) {
+      console.warn("Missing market analysis context", {
+        customer: req.customerMarketAnalysisId,
+        competitor: req.competitorMarketAnalysisId,
+      });
+      continue;
+    }
+
+    const queryVector = await createQueryVector();
+    const customerContext = await fetchMarketAnalysisContext(
+      wv,
+      req.customerDomain,
+      queryVector
+    );
+    const competitorContext = await fetchMarketAnalysisContext(
+      wv,
+      req.competitorDomain,
+      queryVector
+    );
+    const priorCompetition = await fetchCompetitionContext(wv, queryVector);
+
+    const enrichedCustomerAnalysis = buildAnalysisContext(
+      customerMarketAnalysis?.analysis,
+      customerContext
+    );
+    const enrichedCompetitorAnalysis = buildAnalysisContext(
+      competitorMarketAnalysis?.analysis,
+      competitorContext
+    );
+    const priorContext = buildAnalysisContext("", priorCompetition);
+
+    const competitionAnalysis = await GenerateCompetitionAnalysis({
+      ...req,
+      customerMarketAnalysis: `${enrichedCustomerAnalysis}\n\n${priorContext}`.trim(),
+      competitorMarketAnalysis: `${enrichedCompetitorAnalysis}\n\n${priorContext}`.trim(),
+    });
+
+    competitionAnalysis.id = competitionId;
+
+    try {
+      await Model.competitionAnalysis.insertObject(wv, competitionAnalysis);
+    } catch (error) {
+      if (!isDuplicateIdError(error)) {
+        throw error;
+      }
+      console.log("Competition analysis already exists, skipping insert.", competitionId);
+    }
+
+    await linkCompetition(wv, competitionAnalysis);
+  }
+
+  return {
+    statusCode: 202,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ok: true, queued: true }),
+  };
+}
+
+async function createQueryVector() {
+  const response = await oc.embeddings.create({
+    model: "text-embedding-3-small",
+    input: QUESTION_PROMPT,
+  });
+  return response.data[0].embedding;
+}
+
+async function fetchMarketAnalysisContext(client, domain, queryVector) {
+  const col = client.collections.use(Model.marketAnalysis.collectionName);
+  const { objects } = await col.query.nearVector(queryVector, {
+    targetVector: "competitionAnalysisLense",
+    limit: 5,
+    filters: Filters.byProperty("domain").equal(domain),
+    returnProperties: ["analysis", "domain", "customerDomain", "subjectType"],
+  });
+  return objects ?? [];
+}
+
+async function fetchCompetitionContext(client, queryVector) {
+  const col = client.collections.use(Model.competitionAnalysis.collectionName);
+  const { objects } = await col.query.nearVector(queryVector, {
+    limit: 3,
+    returnProperties: [
+      "analysis",
+      "customerDomain",
+      "competitorDomain",
+      "customerLegalName",
+      "competitorLegalName",
+    ],
+  });
+  return objects ?? [];
+}
+
+function buildAnalysisContext(base, objects) {
+  const baseText = typeof base === "string" ? base : "";
+  const extras =
+    objects
+      ?.map((entry) => entry?.properties?.analysis)
+      ?.filter((text) => typeof text === "string" && text.trim().length > 0) ?? [];
+
+  return [baseText, ...extras].filter(Boolean).join("\n\n");
+}
+
+async function linkCompetition(client, competitionAnalysis) {
+  const customerMaster = await Model.companyMasterData.fetchObject(
+    client,
+    competitionAnalysis.customerDomain
+  );
+  const competitorMaster = await Model.companyMasterData.fetchObject(
+    client,
+    competitionAnalysis.competitorDomain
+  );
+
+  if (!customerMaster) {
+    console.warn("Missing customer master data for competition analysis", competitionAnalysis.customerDomain);
+  }
+  if (!competitorMaster) {
+    console.warn("Missing competitor master data for competition analysis", competitionAnalysis.competitorDomain);
+  }
+
+  if (customerMaster) {
+    await Model.companyMasterData.linkObjects(
+      client,
+      "competitionAnalysis",
+      customerMaster,
+      competitionAnalysis
+    );
+  }
+
+  if (competitorMaster) {
+    await Model.competitionAnalysis.linkObjects(
+      client,
+      "competitionMasterData",
+      competitionAnalysis,
+      competitorMaster
+    );
+  }
+}
+
+function isDuplicateIdError(error) {
+  const message = error?.message ?? "";
+  return message.includes("already exists") || message.includes("status code: 422");
+}

--- a/src/handler/createcollection.js
+++ b/src/handler/createcollection.js
@@ -34,4 +34,5 @@ export async function handler(event) {
   await ensureCollection(client, Model.companyNews, overwrite);
   await ensureCollection(client, Model.companyMasterData, overwrite);
   await ensureCollection(client, Model.competingCompanies, overwrite);
+  await ensureCollection(client, Model.competitionAnalysis, overwrite);
 }

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -20,6 +20,7 @@ export default $config({
     const AssessmentQueueDLQ = new sst.aws.Queue("AssessmentQueueDLQ", {})
     const CompetitionQueueDLQ = new sst.aws.Queue("CompetitionQueueDLQ", {})
     const MarketAnalysisQueueDLQ = new sst.aws.Queue("MarketAnalysisQueueDLQ", {})
+    const CompetitionAnalysisQueueDLQ = new sst.aws.Queue("CompetitionAnalysisQueueDLQ", {})
     const NewsQueueDLQ = new sst.aws.Queue("NewsQueueDLQ", {})
     const DownloadQueueDLQ = new sst.aws.Queue("DownloadQueueDLQ", {})
 
@@ -40,6 +41,13 @@ export default $config({
     const MarketAnalysisQueue = new sst.aws.Queue("MarketAnalysisQueue", {
       dlq: {
         queue: MarketAnalysisQueueDLQ.arn,
+        retry: maxReceiveCount,
+      },
+    });
+
+    const CompetitionAnalysisQueue = new sst.aws.Queue("CompetitionAnalysisQueue", {
+      dlq: {
+        queue: CompetitionAnalysisQueueDLQ.arn,
         retry: maxReceiveCount,
       },
     });
@@ -76,6 +84,14 @@ export default $config({
 
     MarketAnalysisQueue.subscribe({
       handler: "src/handler/marketanalysis/subscribe.downstream.handler",
+      link: [OpenAIApiKey, WeaviateAPIKey, CompetitionAnalysisQueue],
+      environment: {
+        WeaviateEndpoint
+      }
+    })
+
+    CompetitionAnalysisQueue.subscribe({
+      handler: "src/handler/competitionanalysis/subscribe.downstream.handler",
       link: [OpenAIApiKey, WeaviateAPIKey],
       environment: {
         WeaviateEndpoint


### PR DESCRIPTION
## Summary
- add a CompetitionAnalysis model with managed vectorization, references, and collection creation support
- generate competition analysis content and embeddings, including a new consumer to assemble Weaviate and vector store context
- enqueue competition analysis jobs after competitor market analysis and wire new queues/handlers in infrastructure

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956adfb376c832b84a5e41578ec6c3b)