### PR TITLE
Add IT strategy and sales prep pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ This project uses SST v3 (ESM JavaScript) with OpenAI + Weaviate. Follow the con
 - Use `model.openAIFormat` to enforce schema formats when possible.
 - If the SDK method does not auto-parse, parse `response.output_text` with the Zod format’s `$parseRaw`.
 - Keep model names and prompt text inside `src/cmd/*` modules.
+- OpenAI structured outputs require all fields to be required; avoid `.optional()` unless the field is also `.nullable()`.
 
 ## Weaviate Conventions
 - Use `getClient()` from `src/weaviate.js`.
@@ -82,6 +83,7 @@ This project uses SST v3 (ESM JavaScript) with OpenAI + Weaviate. Follow the con
   - `name: collectionName`
   - `properties: mapZodToWeaviateProperties(zodSchema)`
 - Zod string fields map to Weaviate `text` (no `string`) to avoid nested-property restrictions.
+- Weaviate reserves the `id` property name; `mapZodToWeaviateProperties` and `insertObject`/`fetchObject` transparently map it to `externalId`.
 
 ## Validation
 - Use `requestValidator` (from `src/util/request.js`) for handler inputs.
@@ -92,6 +94,7 @@ This project uses SST v3 (ESM JavaScript) with OpenAI + Weaviate. Follow the con
 - Competitor assessment/news/analysis reuse the same pipeline (subjectType=`competitor`) without re-running competition.
 - Handlers check Weaviate for existing entries before generating new ones.
 - News download -> vector store file batch (createAndPoll) -> enqueue MarketAnalysis with `vectorStoreId`.
+- Competition analysis -> enqueue IT strategy generation.
 - Queue payloads that include a domain must also include `customerDomain` and `subjectType` (`customer` | `competitor`) and preserve them downstream.
 - If MarketAnalysis already exists, skip generation but still enqueue downstream competition analysis attempts.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Customer Intel processes company data through SST-managed queues and Lambdas to 
 - Secrets set via SST for each stage:
   - `OpenAIApiKey`
   - `WeaviateAPIKey`
+  - `VendorCatalogVectorStoreId` (vector store id for the private vendor/service catalog used in service matching)
 - The Weaviate endpoint is defined in `sst.config.ts` and passed to functions through `environment`.
 
 ## Installation
@@ -30,11 +31,18 @@ pnpx sst secrets set --stage <stage> WeaviateAPIKey <value>
   ```
 - Start the SST dev environment (using `pnpx` via `pnpm dlx`):
   ```bash
-  pnpx sst dev --stage <stage>
-  ```
+pnpx sst dev --stage <stage>
+```
 - Deploy to a stage:
+```bash
+pnpx sst deploy --stage <stage>
+```
+
+### Vendor catalog setup
+- Upload the vendor/service catalog to OpenAI files and create a vector store from it.
+- Store the resulting vector store id in the `VendorCatalogVectorStoreId` secret per stage:
   ```bash
-  pnpx sst deploy --stage <stage>
+  pnpx sst secrets set --stage <stage> VendorCatalogVectorStoreId <vector-store-id>
   ```
 
 ## Manual Lambda invocations
@@ -56,6 +64,12 @@ Use AWS CLI discovery to avoid hardcoding Lambda names. Replace `<stage>` and `e
     --payload '{"legalName":"Example Co","domain":"example.com"}' \
     --cli-binary-format raw-in-base64-out output.json
   ```
+- Trigger IT strategy generation (Phase 1) by enqueueing the IT strategy queue:
+  ```bash
+  aws sqs send-message \
+    --queue-url "$(aws sqs get-queue-url --queue-name customer-intel-ITStrategyQueue --output text --query QueueUrl)" \
+    --message-body '{"customerDomain":"example.com","subjectType":"customer"}'
+  ```
 
 ## Processing flow
 1. **Master data entrypoint** (`src/handler/masterdata/call.downstream.js`, `MasterDataCallDownStreamHandler`): validates the request (including `customerDomain` + `subjectType`, defaulting to a `customer`), generates company master data via OpenAI when missing, stores it in Weaviate, and enqueues the enriched request on `AssessmentQueue`.
@@ -67,12 +81,16 @@ Use AWS CLI discovery to avoid hardcoding Lambda names. Replace `<stage>` and `e
 5. **Vector store loader** (`src/handler/loadintovectorstore/subscribe.poll.js`): downloads each URL (or builds markdown fallbacks), uploads files to OpenAI, ensures the target vector store exists, then uses `vectorStores.fileBatches.createAndPoll` to wait for ingestion before enqueueing `MarketAnalysisQueue` with `customerDomain`, `subjectType`, `industries`, `markets`, `legalName`, `domain`, and `vectorStoreId`.
 6. **Market analysis subscriber** (`src/handler/marketanalysis/subscribe.downstream.js`): fetches or generates market analysis using news signals from the provided `vectorStoreId` via the OpenAI `file_search` tool, stores it, and links it back to the master data record.
 7. **Competition analysis subscriber** (`src/handler/competitionanalysis/subscribe.downstream.js`): combines market analysis context for customer and competitor, generates a comparative analysis, stores it, and links it to both master data records.
-8. **Collection bootstrap** (`src/handler/createcollection.js`, `WeaviateCollectionCreator`): recreates Weaviate collections from the schemas in `src/model.js` using `mapZodToWeaviateProperties`.
+8. **IT strategy subscriber** (`src/handler/itstrategy/subscribe.downstream.js`, `ITStrategyQueue`): loads master data, market analysis, competition analyses, and evidence from Weaviate, generates an IT strategy document (no vendors), stores it, links it to the master record, and enqueues service matching.
+9. **Service matching subscriber** (`src/handler/servicematching/subscribe.downstream.js`, `ServiceMatchingQueue`): fetches the IT strategy and master data, queries the vendor catalog vector store via `file_search`, generates service matches, stores them, links to master data, and enqueues sales meeting preparation.
+10. **Sales meeting prep subscriber** (`src/handler/salesmeetingprep/subscribe.downstream.js`, `SalesMeetingPrepQueue`): compiles the executive briefing, hypotheses, questions, impulses, and POC ideas using master data, IT strategy, and service matching outputs; stores the result and links it to the master record.
+11. **Collection bootstrap** (`src/handler/createcollection.js`, `WeaviateCollectionCreator`): recreates Weaviate collections from the schemas in `src/model.js` using `mapZodToWeaviateProperties`.
 
 ### Payload notes
 - Every queued payload that includes a `domain` must also include the original `customerDomain` and `subjectType` (`customer` | `competitor`).
 - `vectorStoreId` is required for market analysis so the OpenAI `file_search` tool can surface recent news signals.
 - Competitors reuse the same queues as customers; only customers trigger the competition search.
+- IT strategy, service matching, and sales meeting prep queues must include `customerDomain` and `subjectType` and are keyed by the customer domain as their document id.
 
 ## Additional references
 - Model schemas and registry: `src/model.js`
@@ -94,6 +112,11 @@ flowchart TD
   MarketAnalysis --> CompetitionAnalysis[CompetitionAnalysis]
   Competitors --> CompetitionAnalysis
   Master --> CompetitionAnalysis
+  Master --> ITStrategy[ITStrategy]
+  ITStrategy --> ServiceMatching[ServiceMatching]
+  ServiceMatching --> SalesPrep[SalesMeetingPrep]
+  Master --> ServiceMatching
+  Master --> SalesPrep
 ```
 
 ### Notes on evolution
@@ -102,8 +125,11 @@ flowchart TD
 - `CompanyNews` collects source URLs and summaries; its content is uploaded to OpenAI vector stores.
 - `MarketAnalysis` is generated from the vector store and linked back to the master record.
 - `CompetitionAnalysis` ties customer and competitor master data together using market analysis context.
+- `ITStrategy` captures business-driven strategies based on market and competition evidence.
+- `ServiceMatching` maps approved strategies to existing services in the vendor catalog vector store.
+- `SalesMeetingPrep` prepares the executive meeting briefing using approved strategies and service matches.
 
 
 ## Quality Expectation
 
-This is a PoC validating various techniques to create a complex document from a pipeline. Resilieince, Parallelism, Batching, etc. are not optimized in anyway. 
+This is a PoC validating various techniques to create a complex document from a pipeline. Prompts, lenses, and batching/parallelization are intentionally unoptimized, and concepts like retries or larger-scale batching have not been applied. Expect rough edges; prioritize correctness over performance when iterating. 

--- a/src/cmd/generateITStrategy.js
+++ b/src/cmd/generateITStrategy.js
@@ -1,0 +1,97 @@
+import { z } from "zod";
+import OpenAI from "openai";
+import { Resource } from "sst";
+import { domain, legalName, subjectType } from "../model.js";
+import ValidationCreator from "../util/request.js";
+import { generatePrompt } from "../util/openai.js";
+import Model from "../model.js";
+
+const oc = new OpenAI({
+  apiKey: Resource.OpenAIApiKey.value,
+});
+
+const evidenceSchema = z.object({
+  id: z.string().min(1),
+  source: z.string().min(1),
+  text: z.string().min(1),
+});
+
+const competitionSchema = z.object({
+  competitorDomain: domain,
+  competitorLegalName: legalName,
+  analysis: z.string().min(1),
+  summary: z.string().min(1).optional(),
+});
+
+const requestSchema = z.object({
+  customerDomain: domain,
+  subjectType: subjectType.optional(),
+  customerLegalName: legalName,
+  companyProfile: z.record(z.any()).describe("Master data profile for the customer"),
+  companyMarketAnalysis: z
+    .object({
+      analysis: z.string().min(1),
+    })
+    .passthrough()
+    .describe("Market analysis for the customer"),
+  competitionAnalysis: z.array(competitionSchema).default([]),
+  evidence: z.array(evidenceSchema).min(1),
+}).transform((value) => ({
+  ...value,
+  subjectType: value.subjectType ?? "customer",
+})).describe("Request to generate IT strategy without selling");
+
+export const requestValidator = ValidationCreator(requestSchema);
+
+const promptTemplate = {
+  instructions: `You are a senior enterprise IT strategist advising the executive board. You do NOT sell services and you do NOT propose vendors.`,
+  input: `Context (frozen):
+- Customer: <%= req.customerLegalName %> (<%= req.customerDomain %>) subjectType=<%= req.subjectType %>
+- Company profile: <%= JSON.stringify(req.companyProfile, null, 2) %>
+- Market analysis (customer): <%= req.companyMarketAnalysis.analysis %>
+- Competition analysis (summaries): <%= JSON.stringify(req.competitionAnalysis, null, 2) %>
+- Evidence excerpts (id + source + text): <%= JSON.stringify(req.evidence, null, 2) %>
+
+Task:
+- Derive business-driven IT strategies that strengthen competitive advantages, compensate structural weaknesses, and enable new niches.
+- Each strategy must cite at least one evidence id from the provided excerpts.
+
+Constraints:
+- Absolutely no vendors, products, or selling language.
+- Strategies must stay business-driven and traceable to evidence.
+- Avoid buzzwords and generic statements.
+- Keep time horizon as one of: short, mid, long.
+
+Output format (JSON):
+- id = "<%= req.customerDomain %>"
+- customerDomain = "<%= req.customerDomain %>"
+- subjectType = "<%= req.subjectType %>"
+- customerLegalName = "<%= req.customerLegalName %>"
+- strategies: array of { id, name, intent, competitiveRationale, businessCapabilityImpact, itCapabilityImplications, riskIfNotPursued, timeHorizon, evidenceIds }
+- strengthAmplification: strategy ids or names
+- weaknessCompensation: strategy ids or names
+- newNicheDifferentiation: strategy ids or names
+- sources: citations used`,
+};
+
+const model = Model.itStrategy;
+
+export default async function generateITStrategy(request) {
+  const req = requestValidator(request);
+  const prompt = generatePrompt(promptTemplate, { req });
+  const response = await oc.responses.parse({
+    model: "gpt-4.1",
+    tools: [{ type: "web_search" }],
+    ...prompt,
+    ...model.openAIFormat,
+  });
+  const strategy = response.output_parsed;
+  return {
+    ...strategy,
+    id: req.customerDomain,
+    customerDomain: req.customerDomain,
+    subjectType: req.subjectType,
+    customerLegalName: req.customerLegalName,
+    sources: strategy.sources ?? [],
+  };
+}

--- a/src/cmd/generateSalesMeetingPrep.js
+++ b/src/cmd/generateSalesMeetingPrep.js
@@ -1,0 +1,79 @@
+import { z } from "zod";
+import OpenAI from "openai";
+import { Resource } from "sst";
+import { domain, legalName, subjectType } from "../model.js";
+import ValidationCreator from "../util/request.js";
+import { generatePrompt } from "../util/openai.js";
+import Model from "../model.js";
+
+const oc = new OpenAI({
+  apiKey: Resource.OpenAIApiKey.value,
+});
+
+const requestSchema = z.object({
+  customerDomain: domain,
+  subjectType: subjectType.optional(),
+  customerLegalName: legalName,
+  companyProfile: z.record(z.any()).describe("Master data profile for the customer"),
+  itStrategy: Model.itStrategy.zodSchema,
+  serviceMatching: Model.serviceMatching.zodSchema,
+}).transform((value) => ({
+  ...value,
+  subjectType: value.subjectType ?? "customer",
+})).describe("Request to prepare a sales meeting briefing");
+
+export const requestValidator = ValidationCreator(requestSchema);
+
+const promptTemplate = {
+  instructions: `You are a senior sales engineer preparing an executive meeting. You seek insight and trust, not closing.`,
+  input: `Context (frozen):
+- Customer: <%= req.customerLegalName %> (<%= req.customerDomain %>) subjectType=<%= req.subjectType %>
+- Company profile: <%= JSON.stringify(req.companyProfile, null, 2) %>
+- IT strategies (approved): <%= JSON.stringify(req.itStrategy.strategies, null, 2) %>
+- Service matches: <%= JSON.stringify(req.serviceMatching.matches, null, 2) %>
+
+Task:
+- Prepare the meeting briefing with executive context, strategic hypotheses, smart questions (each tied to a strategy), strategic impulses (non-salesy), and low-risk POC ideas (objective, scope, success criteria).
+
+Constraints:
+- No generic sales language.
+- Do not introduce services not present in the service matching output.
+- Prioritize the 3-5 most relevant strategies for the meeting.
+- Every question must cite the related strategy id or name.
+- POCs must be exploratory and low-risk.
+
+Output format (JSON):
+- id = "<%= req.customerDomain %>"
+- customerDomain = "<%= req.customerDomain %>"
+- subjectType = "<%= req.subjectType %>"
+- customerLegalName = "<%= req.customerLegalName %>"
+- itStrategyId = "<%= req.itStrategy.id %>"
+- serviceMatchingId = "<%= req.serviceMatching.id %>"
+- executiveBriefing
+- strategicHypotheses
+- questionsToAsk
+- strategicImpulses
+- pocIdeas [{ objective, scope, successCriteria }]`,
+};
+
+const model = Model.salesMeetingPrep;
+
+export default async function generateSalesMeetingPrep(request) {
+  const req = requestValidator(request);
+  const prompt = generatePrompt(promptTemplate, { req });
+  const response = await oc.responses.parse({
+    model: "gpt-4.1-mini",
+    ...prompt,
+    ...model.openAIFormat,
+  });
+  const prep = response.output_parsed;
+  return {
+    ...prep,
+    id: req.customerDomain,
+    customerDomain: req.customerDomain,
+    subjectType: req.subjectType,
+    customerLegalName: req.customerLegalName,
+    itStrategyId: req.itStrategy.id,
+    serviceMatchingId: req.serviceMatching.id,
+  };
+}

--- a/src/cmd/generateServiceMatching.js
+++ b/src/cmd/generateServiceMatching.js
@@ -1,0 +1,81 @@
+import { z } from "zod";
+import OpenAI from "openai";
+import { Resource } from "sst";
+import { domain, legalName, subjectType } from "../model.js";
+import ValidationCreator from "../util/request.js";
+import { generatePrompt } from "../util/openai.js";
+import Model from "../model.js";
+
+const oc = new OpenAI({
+  apiKey: Resource.OpenAIApiKey.value,
+});
+
+const requestSchema = z.object({
+  customerDomain: domain,
+  subjectType: subjectType.optional(),
+  customerLegalName: legalName,
+  itStrategy: Model.itStrategy.zodSchema,
+  companyProfile: z.record(z.any()).describe("Master data profile for the customer"),
+  vendorCatalogVectorStoreId: z.string().min(1),
+}).transform((value) => ({
+  ...value,
+  subjectType: value.subjectType ?? "customer",
+})).describe("Request to map IT strategies to vendor services");
+
+export const requestValidator = ValidationCreator(requestSchema);
+
+const promptTemplate = {
+  instructions: `You are a solution architect at an IT service provider. You align client IT strategies with existing services only.`,
+  input: `Context (frozen):
+- Customer: <%= req.customerLegalName %> (<%= req.customerDomain %>) subjectType=<%= req.subjectType %>
+- Company profile: <%= JSON.stringify(req.companyProfile, null, 2) %>
+- IT strategies: <%= JSON.stringify(req.itStrategy.strategies, null, 2) %>
+- Vendor catalog vector store id: <%= req.vendorCatalogVectorStoreId %>
+
+Task:
+- For each IT strategy, identify supporting services from the vendor catalog (via file_search).
+- Explain the value contribution briefly.
+- Provide entry-level engagement ideas.
+- Call out gaps explicitly when no service matches.
+
+Constraints:
+- Use file_search with vector store id "<%= req.vendorCatalogVectorStoreId %>" to retrieve vendor services.
+- Do NOT invent services. Do NOT use web_search.
+- Keep rationales short and concrete.
+- If no match exists, set supportingServices to [] and gaps to ["no matching service"].
+
+Output format (JSON):
+- id = "<%= req.customerDomain %>"
+- customerDomain = "<%= req.customerDomain %>"
+- subjectType = "<%= req.subjectType %>"
+- customerLegalName = "<%= req.customerLegalName %>"
+- itStrategyId = "<%= req.itStrategy.id %>"
+- matches: array of { strategyName, supportingServices, valueContribution, entryLevelEngagementIdeas, gaps }`,
+};
+
+const model = Model.serviceMatching;
+
+export default async function generateServiceMatching(request) {
+  const req = requestValidator(request);
+  const prompt = generatePrompt(promptTemplate, { req });
+  const response = await oc.responses.parse({
+    model: "gpt-4.1-mini",
+    tools: [
+      {
+        type: "file_search",
+        vector_store_ids: [req.vendorCatalogVectorStoreId],
+      },
+    ],
+    ...prompt,
+    ...model.openAIFormat,
+  });
+  const matching = response.output_parsed;
+  return {
+    ...matching,
+    id: req.customerDomain,
+    customerDomain: req.customerDomain,
+    subjectType: req.subjectType,
+    customerLegalName: req.customerLegalName,
+    itStrategyId: req.itStrategy.id,
+  };
+}

--- a/src/handler/createcollection.js
+++ b/src/handler/createcollection.js
@@ -35,4 +35,7 @@ export async function handler(event) {
   await ensureCollection(client, Model.companyMasterData, overwrite);
   await ensureCollection(client, Model.competingCompanies, overwrite);
   await ensureCollection(client, Model.competitionAnalysis, overwrite);
+  await ensureCollection(client, Model.itStrategy, overwrite);
+  await ensureCollection(client, Model.serviceMatching, overwrite);
+  await ensureCollection(client, Model.salesMeetingPrep, overwrite);
 }

--- a/src/handler/itstrategy/subscribe.downstream.js
+++ b/src/handler/itstrategy/subscribe.downstream.js
@@ -1,0 +1,228 @@
+import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
+import OpenAI from "openai";
+import { Resource } from "sst";
+import { z } from "zod";
+import generateITStrategy from "../../cmd/generateITStrategy.js";
+import { getClient } from "../../weaviate.js";
+import Model, { domain, subjectType } from "../../model.js";
+import ValidationCreator from "../../util/request.js";
+
+const requestSchema = z.object({
+  customerDomain: domain,
+  subjectType: subjectType.optional(),
+}).transform((value) => ({
+  ...value,
+  subjectType: value.subjectType ?? "customer",
+}));
+
+const requestValidator = ValidationCreator(requestSchema);
+
+const sqs = new SQSClient({});
+const oc = new OpenAI({
+  apiKey: Resource.OpenAIApiKey.value,
+});
+
+const EVIDENCE_QUERY =
+  "Evidence for IT strategy: competitive strengths/weaknesses, market positioning, trend alignment, innovation posture, customer expectations.";
+const MAX_EVIDENCE = 12;
+
+export async function handler(event) {
+  for (const record of event.Records ?? []) {
+    const req = requestValidator(record.body);
+    const wv = await getClient();
+
+    const strategyId = req.customerDomain;
+    let strategy = await Model.itStrategy.fetchObject(wv, strategyId);
+
+    if (!strategy) {
+      console.log("Generating IT strategy", req.customerDomain);
+      const master = await Model.companyMasterData.fetchObject(wv, req.customerDomain);
+      if (!master) {
+        console.warn("Missing master data for IT strategy", req.customerDomain);
+        continue;
+      }
+
+      const marketAnalysis = await Model.marketAnalysis.fetchObject(wv, req.customerDomain);
+      if (!marketAnalysis) {
+        console.warn("Missing market analysis for IT strategy", req.customerDomain);
+        continue;
+      }
+
+      const competitionAnalyses = await fetchCompetitionAnalyses(wv, req.customerDomain);
+      let evidence = await collectEvidence(wv, req.customerDomain, competitionAnalyses);
+      if (!evidence.length && marketAnalysis?.analysis) {
+        evidence = [
+          {
+            id: `${req.customerDomain}-market-analysis`,
+            source: req.customerDomain,
+            text: truncateText(marketAnalysis.analysis, 800),
+          },
+        ];
+      }
+
+      strategy = await generateITStrategy({
+        customerDomain: req.customerDomain,
+        subjectType: req.subjectType,
+        customerLegalName: master.legalName,
+        companyProfile: master,
+        companyMarketAnalysis: marketAnalysis,
+        competitionAnalysis: competitionAnalyses,
+        evidence,
+      });
+
+      try {
+        await Model.itStrategy.insertObject(wv, strategy);
+      } catch (error) {
+        if (!isDuplicateIdError(error)) {
+          throw error;
+        }
+        strategy = await Model.itStrategy.fetchObject(wv, strategyId);
+      }
+
+      await Model.companyMasterData.linkObjects(wv, "itStrategy", master, strategy);
+    } else {
+      console.log("IT strategy already exists, skipping generation", req.customerDomain);
+    }
+
+    await enqueueServiceMatching(req, strategy);
+  }
+
+  return {
+    statusCode: 202,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ok: true, queued: true }),
+  };
+}
+
+async function enqueueServiceMatching(req, strategy) {
+  if (!strategy) {
+    console.warn("Missing IT strategy, cannot enqueue service matching", req.customerDomain);
+    return;
+  }
+
+  const vendorCatalogVectorStoreId = Resource.VendorCatalogVectorStoreId?.value;
+  if (!vendorCatalogVectorStoreId) {
+    console.warn("VendorCatalogVectorStoreId is not configured; skipping service matching enqueue");
+    return;
+  }
+
+  const payload = {
+    customerDomain: req.customerDomain,
+    subjectType: req.subjectType,
+    customerLegalName: strategy.customerLegalName,
+    itStrategyId: strategy.id,
+    vendorCatalogVectorStoreId,
+  };
+
+  await sqs.send(
+    new SendMessageCommand({
+      QueueUrl: Resource.ServiceMatchingQueue.url,
+      MessageBody: JSON.stringify(payload),
+    })
+  );
+}
+
+async function fetchCompetitionAnalyses(client, customerDomain) {
+  const col = client.collections.use(Model.competitionAnalysis.collectionName);
+  const { objects } = await col.query.hybrid(
+    customerDomain,
+    {
+      limit: 8,
+      filters: col.filter.byProperty("customerDomain").equal(customerDomain),
+      returnProperties: [
+        "competitionId",
+        "customerDomain",
+        "competitorDomain",
+        "customerLegalName",
+        "competitorLegalName",
+        "analysis",
+        "summary",
+      ],
+    }
+  );
+
+  return (
+    objects?.map((entry) => ({
+      competitorDomain: entry?.properties?.competitorDomain,
+      competitorLegalName: entry?.properties?.competitorLegalName,
+      analysis: entry?.properties?.analysis,
+      summary: entry?.properties?.summary,
+    }))?.filter((entry) => entry?.competitorDomain && entry?.analysis) ?? []
+  );
+}
+
+async function collectEvidence(client, customerDomain, competitionAnalyses) {
+  const queryVector = await createQueryVector();
+  const customerEvidence = await fetchMarketEvidence(
+    client,
+    customerDomain,
+    queryVector
+  );
+
+  const competitorEvidence = [];
+  for (const entry of competitionAnalyses ?? []) {
+    const items = await fetchMarketEvidence(
+      client,
+      entry.competitorDomain,
+      queryVector,
+      2
+    );
+    competitorEvidence.push(...items);
+  }
+
+  const combined = [...customerEvidence, ...competitorEvidence];
+  const deduped = [];
+  const seen = new Set();
+  for (const item of combined) {
+    const key = item.source ?? item.id;
+    if (key && !seen.has(key)) {
+      deduped.push(item);
+      seen.add(key);
+    }
+    if (deduped.length >= MAX_EVIDENCE) {
+      break;
+    }
+  }
+  return deduped;
+}
+
+async function fetchMarketEvidence(client, domainId, vector, limit = 8) {
+  const col = client.collections.use(Model.marketAnalysis.collectionName);
+  const { objects } = await col.query.nearVector(vector, {
+    targetVector: "marketAnalysisText",
+    limit,
+    filters: col.filter.byProperty("domain").equal(domainId),
+    returnProperties: ["analysis", "domain", "customerDomain", "subjectType"],
+  });
+
+  return (
+    objects?.map((entry) => ({
+      id: entry?.uuid ?? entry?.properties?.domain ?? domainId,
+      source: entry?.properties?.domain ?? domainId,
+      text: entry?.properties?.analysis,
+    }))?.filter((item) => item.text)?.map((item) => ({
+      ...item,
+      text: truncateText(item.text, 800),
+    })) ?? []
+  );
+}
+
+async function createQueryVector() {
+  const response = await oc.embeddings.create({
+    model: "text-embedding-3-small",
+    input: EVIDENCE_QUERY,
+  });
+  return response.data[0].embedding;
+}
+
+function truncateText(text, maxLength) {
+  if (!text || text.length <= maxLength) {
+    return text;
+  }
+  return `${text.slice(0, maxLength)}...`;
+}
+
+function isDuplicateIdError(error) {
+  const message = error?.message ?? "";
+  return message.includes("already exists") || message.includes("status code: 422");
+}

--- a/src/handler/salesmeetingprep/subscribe.downstream.js
+++ b/src/handler/salesmeetingprep/subscribe.downstream.js
@@ -1,0 +1,83 @@
+import { z } from "zod";
+import generateSalesMeetingPrep from "../../cmd/generateSalesMeetingPrep.js";
+import { getClient } from "../../weaviate.js";
+import Model, { domain, subjectType, legalName } from "../../model.js";
+import ValidationCreator from "../../util/request.js";
+
+const requestSchema = z.object({
+  customerDomain: domain,
+  subjectType: subjectType.optional(),
+  customerLegalName: legalName,
+  itStrategyId: z.string().min(1),
+  serviceMatchingId: z.string().min(1),
+}).transform((value) => ({
+  ...value,
+  subjectType: value.subjectType ?? "customer",
+}));
+
+const requestValidator = ValidationCreator(requestSchema);
+
+export async function handler(event) {
+  for (const record of event.Records ?? []) {
+    const req = requestValidator(record.body);
+    const wv = await getClient();
+    const salesPrepId = req.customerDomain;
+
+    let prep = await Model.salesMeetingPrep.fetchObject(wv, salesPrepId);
+    if (!prep) {
+      const master = await Model.companyMasterData.fetchObject(wv, req.customerDomain);
+      if (!master) {
+        console.warn("Missing master data for sales meeting prep", req.customerDomain);
+        continue;
+      }
+
+      const itStrategy = await Model.itStrategy.fetchObject(wv, req.itStrategyId);
+      if (!itStrategy) {
+        console.warn("Missing IT strategy for sales meeting prep", req.itStrategyId);
+        continue;
+      }
+
+      const serviceMatching = await Model.serviceMatching.fetchObject(
+        wv,
+        req.serviceMatchingId
+      );
+      if (!serviceMatching) {
+        console.warn("Missing service matching for sales meeting prep", req.serviceMatchingId);
+        continue;
+      }
+
+      prep = await generateSalesMeetingPrep({
+        customerDomain: req.customerDomain,
+        subjectType: req.subjectType,
+        customerLegalName: req.customerLegalName,
+        companyProfile: master,
+        itStrategy,
+        serviceMatching,
+      });
+
+      try {
+        await Model.salesMeetingPrep.insertObject(wv, prep);
+      } catch (error) {
+        if (!isDuplicateIdError(error)) {
+          throw error;
+        }
+        prep = await Model.salesMeetingPrep.fetchObject(wv, salesPrepId);
+      }
+
+      await Model.companyMasterData.linkObjects(wv, "salesMeetingPrep", master, prep);
+    } else {
+      console.log("Sales meeting prep already exists, skipping generation", req.customerDomain);
+    }
+  }
+
+  return {
+    statusCode: 202,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ok: true, queued: true }),
+  };
+}
+
+function isDuplicateIdError(error) {
+  const message = error?.message ?? "";
+  return message.includes("already exists") || message.includes("status code: 422");
+}

--- a/src/handler/servicematching/subscribe.downstream.js
+++ b/src/handler/servicematching/subscribe.downstream.js
@@ -1,0 +1,109 @@
+import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
+import { Resource } from "sst";
+import { z } from "zod";
+import generateServiceMatching from "../../cmd/generateServiceMatching.js";
+import { getClient } from "../../weaviate.js";
+import Model, { domain, subjectType, legalName } from "../../model.js";
+import ValidationCreator from "../../util/request.js";
+
+const requestSchema = z.object({
+  customerDomain: domain,
+  subjectType: subjectType.optional(),
+  customerLegalName: legalName,
+  itStrategyId: z.string().min(1),
+  vendorCatalogVectorStoreId: z.string().min(1).optional(),
+}).transform((value) => ({
+  ...value,
+  subjectType: value.subjectType ?? "customer",
+}));
+
+const requestValidator = ValidationCreator(requestSchema);
+const sqs = new SQSClient({});
+
+export async function handler(event) {
+  for (const record of event.Records ?? []) {
+    const req = requestValidator(record.body);
+    const vendorCatalogVectorStoreId =
+      req.vendorCatalogVectorStoreId ?? Resource.VendorCatalogVectorStoreId?.value;
+
+    if (!vendorCatalogVectorStoreId) {
+      console.warn("Vendor catalog vector store id missing, skipping service matching", req.customerDomain);
+      continue;
+    }
+
+    const wv = await getClient();
+    const serviceMatchingId = req.customerDomain;
+
+    let matching = await Model.serviceMatching.fetchObject(wv, serviceMatchingId);
+    if (!matching) {
+      const master = await Model.companyMasterData.fetchObject(wv, req.customerDomain);
+      if (!master) {
+        console.warn("Missing master data for service matching", req.customerDomain);
+        continue;
+      }
+
+      const itStrategy = await Model.itStrategy.fetchObject(wv, req.itStrategyId);
+      if (!itStrategy) {
+        console.warn("Missing IT strategy for service matching", req.itStrategyId);
+        continue;
+      }
+
+      matching = await generateServiceMatching({
+        customerDomain: req.customerDomain,
+        subjectType: req.subjectType,
+        customerLegalName: req.customerLegalName,
+        itStrategy,
+        companyProfile: master,
+        vendorCatalogVectorStoreId,
+      });
+
+      try {
+        await Model.serviceMatching.insertObject(wv, matching);
+      } catch (error) {
+        if (!isDuplicateIdError(error)) {
+          throw error;
+        }
+        matching = await Model.serviceMatching.fetchObject(wv, serviceMatchingId);
+      }
+
+      await Model.companyMasterData.linkObjects(wv, "serviceMatching", master, matching);
+    } else {
+      console.log("Service matching already exists, skipping generation", req.customerDomain);
+    }
+
+    await enqueueSalesMeetingPrep(req, matching);
+  }
+
+  return {
+    statusCode: 202,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ok: true, queued: true }),
+  };
+}
+
+async function enqueueSalesMeetingPrep(req, matching) {
+  if (!matching) {
+    console.warn("Missing service matching output, cannot enqueue sales meeting prep", req.customerDomain);
+    return;
+  }
+
+  const payload = {
+    customerDomain: req.customerDomain,
+    subjectType: req.subjectType,
+    customerLegalName: matching.customerLegalName ?? req.customerLegalName,
+    itStrategyId: req.itStrategyId,
+    serviceMatchingId: matching.id,
+  };
+
+  await sqs.send(
+    new SendMessageCommand({
+      QueueUrl: Resource.SalesMeetingPrepQueue.url,
+      MessageBody: JSON.stringify(payload),
+    })
+  );
+}
+
+function isDuplicateIdError(error) {
+  const message = error?.message ?? "";
+  return message.includes("already exists") || message.includes("status code: 422");
+}

--- a/src/model.js
+++ b/src/model.js
@@ -105,12 +105,76 @@ const companyNews = z.object({
   date: z.string().min(1).describe("Publication date in ISO 8601 format (YYYY-MM-DD)"),
 }).describe("News item about a company")
 
+const strategy = z.object({
+  id: z.string().min(1).describe("Stable strategy identifier"),
+  name: z.string().min(1).describe("Strategy title"),
+  intent: z.string().min(1).describe("Why the strategy matters now"),
+  competitiveRationale: z.string().min(1).describe("Why this helps vs competitors"),
+  businessCapabilityImpact: z.string().min(1).describe("Business capability uplift"),
+  itCapabilityImplications: z.string().min(1).describe("IT capability changes implied"),
+  riskIfNotPursued: z.string().min(1).describe("Risk if the strategy is ignored"),
+  timeHorizon: z.enum(["short", "mid", "long"]).describe("Time horizon for the strategy"),
+  evidenceIds: z.array(z.string().min(1)).min(1).describe("Evidence ids backing the strategy"),
+}).describe("Individual IT strategy")
+
+const itStrategy = z.object({
+  id: z.string().min(1).describe("Stable identifier for the IT strategy document (use customer domain)"),
+  customerDomain: domain,
+  subjectType,
+  customerLegalName: legalName,
+  strategies: z.array(strategy).min(1).describe("List of business-driven IT strategies"),
+  strengthAmplification: z.array(z.string().min(1)).describe("Strategies that amplify strengths"),
+  weaknessCompensation: z.array(z.string().min(1)).describe("Strategies that compensate weaknesses"),
+  newNicheDifferentiation: z.array(z.string().min(1)).describe("Strategies to open new niches"),
+  sources: z.array(z.string().min(1)).optional().describe("Citations backing the strategy document"),
+}).describe("IT strategy document without selling content")
+
+const serviceMatch = z.object({
+  strategyName: z.string().min(1).describe("Strategy the services align to"),
+  supportingServices: z.array(z.string().min(1)).describe("Services that support the strategy"),
+  valueContribution: z.string().min(1).describe("Why the service fits the strategy"),
+  entryLevelEngagementIdeas: z.array(z.string().min(1)).describe("Low-risk engagement ideas"),
+  gaps: z.array(z.string().min(1)).optional().describe("Gaps where no service matches"),
+}).describe("Service match for a strategy")
+
+const serviceMatching = z.object({
+  id: z.string().min(1).describe("Stable identifier for the service matching document (use customer domain)"),
+  customerDomain: domain,
+  subjectType,
+  customerLegalName: legalName,
+  itStrategyId: z.string().min(1).describe("Identifier of the linked IT strategy"),
+  matches: z.array(serviceMatch).min(1).describe("Service mappings for each strategy"),
+}).describe("Mapping of IT strategies to vendor services")
+
+const pocIdea = z.object({
+  objective: z.string().min(1).describe("Objective of the proof of concept"),
+  scope: z.string().min(1).describe("Scope of the proof of concept"),
+  successCriteria: z.array(z.string().min(1)).describe("Success criteria for the proof of concept"),
+}).describe("POC idea")
+
+const salesMeetingPrep = z.object({
+  id: z.string().min(1).describe("Stable identifier for the sales meeting prep document (use customer domain)"),
+  customerDomain: domain,
+  subjectType,
+  customerLegalName: legalName,
+  itStrategyId: z.string().min(1).describe("Identifier of the linked IT strategy"),
+  serviceMatchingId: z.string().min(1).describe("Identifier of the linked service matching output"),
+  executiveBriefing: z.string().min(1).describe("Executive-ready briefing summary"),
+  strategicHypotheses: z.array(z.string().min(1)).describe("Hypotheses to validate during the meeting"),
+  questionsToAsk: z.array(z.string().min(1)).describe("Questions tied to strategies"),
+  strategicImpulses: z.array(z.string().min(1)).describe("Non-salesy impulses to explore"),
+  pocIdeas: z.array(pocIdea).describe("Concrete POC ideas"),
+}).describe("Sales meeting preparation output")
+
 const COMPANY_MASTER_DATA_COLLECTION = "CompanyMasterData";
 const COMPANY_ASSESSMENT_COLLECTION = "CompanyAssessment";
 const COMPETING_COMPANIES_COLLECTION = "CompetingCompanies";
 const MARKET_ANALYSIS_COLLECTION = "MarketAnalysis";
 const COMPETITION_ANALYSIS_COLLECTION = "CompetitionAnalysis";
 const COMPANY_NEWS_COLLECTION = "CompanyNews";
+const IT_STRATEGY_COLLECTION = "ITStrategy";
+const SERVICE_MATCHING_COLLECTION = "ServiceMatching";
+const SALES_MEETING_PREP_COLLECTION = "SalesMeetingPrep";
 
 const buildVectorizers = (vectorNamesList, managedVectorizerConfig) => {
   const configured = [];
@@ -191,6 +255,9 @@ const registry = {
       "news": COMPANY_NEWS_COLLECTION,
       "competingCompanies": COMPANY_MASTER_DATA_COLLECTION,
       "competitionAnalysis": COMPETITION_ANALYSIS_COLLECTION,
+      "itStrategy": IT_STRATEGY_COLLECTION,
+      "serviceMatching": SERVICE_MATCHING_COLLECTION,
+      "salesMeetingPrep": SALES_MEETING_PREP_COLLECTION,
     },
     []
   ),
@@ -238,6 +305,27 @@ const registry = {
     "source",
     {},
     ["newsAnalysisLense"]
+  ),
+  itStrategy: generateModelRegistryEntry(
+    itStrategy,
+    IT_STRATEGY_COLLECTION,
+    "id",
+    {},
+    []
+  ),
+  serviceMatching: generateModelRegistryEntry(
+    serviceMatching,
+    SERVICE_MATCHING_COLLECTION,
+    "id",
+    {},
+    []
+  ),
+  salesMeetingPrep: generateModelRegistryEntry(
+    salesMeetingPrep,
+    SALES_MEETING_PREP_COLLECTION,
+    "id",
+    {},
+    []
   ),
 };
 

--- a/src/model.js
+++ b/src/model.js
@@ -126,7 +126,7 @@ const itStrategy = z.object({
   strengthAmplification: z.array(z.string().min(1)).describe("Strategies that amplify strengths"),
   weaknessCompensation: z.array(z.string().min(1)).describe("Strategies that compensate weaknesses"),
   newNicheDifferentiation: z.array(z.string().min(1)).describe("Strategies to open new niches"),
-  sources: z.array(z.string().min(1)).optional().describe("Citations backing the strategy document"),
+  sources: z.array(z.string().min(1)).describe("Citations backing the strategy document"),
 }).describe("IT strategy document without selling content")
 
 const serviceMatch = z.object({
@@ -134,7 +134,7 @@ const serviceMatch = z.object({
   supportingServices: z.array(z.string().min(1)).describe("Services that support the strategy"),
   valueContribution: z.string().min(1).describe("Why the service fits the strategy"),
   entryLevelEngagementIdeas: z.array(z.string().min(1)).describe("Low-risk engagement ideas"),
-  gaps: z.array(z.string().min(1)).optional().describe("Gaps where no service matches"),
+  gaps: z.array(z.string().min(1)).describe("Gaps where no service matches"),
 }).describe("Service match for a strategy")
 
 const serviceMatching = z.object({

--- a/sst-env.d.ts
+++ b/sst-env.d.ts
@@ -37,6 +37,14 @@ declare module "sst" {
       "type": "sst.aws.Queue"
       "url": string
     }
+    "ITStrategyQueue": {
+      "type": "sst.aws.Queue"
+      "url": string
+    }
+    "ITStrategyQueueDLQ": {
+      "type": "sst.aws.Queue"
+      "url": string
+    }
     "MarketAnalysisQueue": {
       "type": "sst.aws.Queue"
       "url": string
@@ -58,6 +66,26 @@ declare module "sst" {
       "url": string
     }
     "OpenAIApiKey": {
+      "type": "sst.sst.Secret"
+      "value": string
+    }
+    "SalesMeetingPrepQueue": {
+      "type": "sst.aws.Queue"
+      "url": string
+    }
+    "SalesMeetingPrepQueueDLQ": {
+      "type": "sst.aws.Queue"
+      "url": string
+    }
+    "ServiceMatchingQueue": {
+      "type": "sst.aws.Queue"
+      "url": string
+    }
+    "ServiceMatchingQueueDLQ": {
+      "type": "sst.aws.Queue"
+      "url": string
+    }
+    "VendorCatalogVectorStoreId": {
       "type": "sst.sst.Secret"
       "value": string
     }

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -117,7 +117,7 @@ export default $config({
 
     CompetitionAnalysisQueue.subscribe({
       handler: "src/handler/competitionanalysis/subscribe.downstream.handler",
-      link: [OpenAIApiKey, WeaviateAPIKey],
+      link: [OpenAIApiKey, WeaviateAPIKey, ITStrategyQueue],
       environment: {
         WeaviateEndpoint
       }


### PR DESCRIPTION
## Summary
- add ITStrategy, ServiceMatching, and SalesMeetingPrep schemas with new SST queues and secrets
- implement generators plus queue subscribers for IT strategy, service matching, and sales meeting preparation flows
- refresh documentation for vendor catalog setup, new queues, pipeline diagram, and clarify PoC quality expectations (prompts/lenses/batching unoptimized)

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956ce65f60c832bb1dcb5b0e6e59701)